### PR TITLE
Vanilla Boat requires piers in party for character shuffle

### DIFF
--- a/randomiser/game_logic/locations/LemurianShip.json
+++ b/randomiser/game_logic/locations/LemurianShip.json
@@ -2,7 +2,14 @@
     "Access": [
         [
             "Black Crystal",
-            "GabombaCleared"
+            "GabombaCleared",
+            "Piers"
+        ],
+        [
+            "Black Crystal",
+            "GabombaCleared",
+            "FlagPiers",
+            "VanillaCharacters"
         ],
         [
             "ShipOpen"

--- a/randomiser/game_logic/randomisers/item_randomiser.js
+++ b/randomiser/game_logic/randomisers/item_randomiser.js
@@ -172,6 +172,7 @@ class ItemRandomiser {
         if (this.settings['skips-oob-easy']) set.push('SkipOobEasy');
         if (this.settings['skips-oob-hard']) set.push('SkipOobHard');
         if (this.settings['skips-maze']) set.push('SkipMaze');
+        if (!this.settings['shuffle-characters']) set.push('VanillaCharacters');
         return set;
     }
 


### PR DESCRIPTION
Made a tentative patch for the issues by doing the following two changes ;

- Adds check for piers in party for vanilla boat access
- Adds a flag for vanilla characters added when shuffle is turned off, so that FlagPiers + VanillaCharacters = Piers

Another way to correct the issue would be to set the flag for piers "joining" the party when clearing gabomba or talking to the mayor ?